### PR TITLE
Authentication cookie

### DIFF
--- a/LazZiya.ExpressLocalization/ExpressLocalizationExtensions.cs
+++ b/LazZiya.ExpressLocalization/ExpressLocalizationExtensions.cs
@@ -12,6 +12,11 @@ using LazZiya.TagHelpers;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using System.Threading.Tasks;
 
+#if NETCOREAPP3_0
+#else
+using Microsoft.AspNetCore.Routing;
+#endif
+
 namespace LazZiya.ExpressLocalization
 {
     /// <summary>
@@ -87,6 +92,12 @@ namespace LazZiya.ExpressLocalization
 
             builder.Services.Configure<RequestLocalizationOptions>(_options.RequestLocalizationOptions);
 
+            if (_options.ConfigureRedirectPaths)
+                builder.ExConfigureApplicationCookie(_options.LoginPath, _options.LogoutPath, _options.AccessDeniedPath, _options.DefaultCultureName);
+
+            if (_options.ConfigureRedirectPaths)
+                builder.ExConfigureApplicationCookie(_options.LoginPath, _options.LogoutPath, _options.AccessDeniedPath, _options.DefaultCultureName);
+
             return builder
                 .AddViewLocalization(ops=> { ops.ResourcesPath = _options.ResourcesPath; })
                 .ExAddSharedCultureLocalizer<TViewLocalizationResource>()
@@ -128,6 +139,9 @@ namespace LazZiya.ExpressLocalization
             _options.RequestLocalizationOptions.Invoke(_ops);
 
             builder.Services.Configure<RequestLocalizationOptions>(_options.RequestLocalizationOptions);
+
+            if (_options.ConfigureRedirectPaths)
+                builder.ExConfigureApplicationCookie(_options.LoginPath, _options.LogoutPath, _options.AccessDeniedPath, _options.DefaultCultureName);
 
             return builder
                 .AddViewLocalization(ops => { ops.ResourcesPath = _options.ResourcesPath; })
@@ -279,9 +293,9 @@ namespace LazZiya.ExpressLocalization
                     OnRedirectToLogout = ctx =>
                     {
 #if NETCOREAPP3_0
-                        var culture = ctx.Request.RouteValues["culture"];
+                        var culture = ctx.Request.RouteValues["culture"] ?? defCulture;
 #else
-                        var culture = ctx.HttpContext.GetRouteValue("culture");
+                        var culture = ctx.HttpContext.GetRouteValue("culture") ?? defCulture;
 #endif
                         ctx.Response.Redirect($"/{culture}{logoutPath}");
                         return Task.CompletedTask;
@@ -289,9 +303,9 @@ namespace LazZiya.ExpressLocalization
                     OnRedirectToAccessDenied = ctx =>
                     {
 #if NETCOREAPP3_0
-                        var culture = ctx.Request.RouteValues["culture"];
+                        var culture = ctx.Request.RouteValues["culture"] ?? defCulture;
 #else
-                        var culture = ctx.HttpContext.GetRouteValue("culture");
+                        var culture = ctx.HttpContext.GetRouteValue("culture") ?? defCulture;
 #endif
                         ctx.Response.Redirect($"/{culture}{accessDeniedPath}");
                         return Task.CompletedTask;

--- a/LazZiya.ExpressLocalization/ExpressLocalizationOptions.cs
+++ b/LazZiya.ExpressLocalization/ExpressLocalizationOptions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Builder;
+
 using System;
 
 namespace LazZiya.ExpressLocalization
@@ -17,5 +19,30 @@ namespace LazZiya.ExpressLocalization
         /// The path to the resources folder e.g. "LocalizationResources"
         /// </summary>
         public string ResourcesPath { get; set; } = "";
+
+        /// <summary>
+        /// Configure application cookie opitons,
+        /// <para>mainly used to add culture value to redirect to login path and access denied path</para>
+        /// <para>if not set manually, the default settings will be applied by adding culture parameter to the relevant paths</para>
+        /// </summary>
+        public Action<CookieAuthenticationOptions> CookieAuthenticationOptions { get; set; }
+        /// <summary>
+        /// Add culture parameter to login path.
+        /// Done by configuring application cookie options event
+        /// <para>default value = true</para>
+        /// <para>set to false if you need to configure the application cookie options manually</para>
+        /// </summary>
+        public bool ConfigureRedirectToLoginPath { get; set; } = true;
+
+        /// <summary>
+        /// The default culture to set during redirection to login event if no culture was set.
+        /// </summary>
+        public string DefaultCultureName { get; set; } = "en";
+
+        /// <summary>
+        /// The default login path
+        /// <para>default value = "/Identity/Account/Login/"</para>
+        /// </summary>
+        public string LoginPath { get; set; } = "/Identity/Account/Login/";
     }
 }

--- a/LazZiya.ExpressLocalization/ExpressLocalizationOptions.cs
+++ b/LazZiya.ExpressLocalization/ExpressLocalizationOptions.cs
@@ -21,18 +21,11 @@ namespace LazZiya.ExpressLocalization
         public string ResourcesPath { get; set; } = "";
 
         /// <summary>
-        /// Configure application cookie opitons,
-        /// <para>mainly used to add culture value to redirect to login path and access denied path</para>
-        /// <para>if not set manually, the default settings will be applied by adding culture parameter to the relevant paths</para>
-        /// </summary>
-        public Action<CookieAuthenticationOptions> CookieAuthenticationOptions { get; set; }
-        /// <summary>
-        /// Add culture parameter to login path.
-        /// Done by configuring application cookie options event
+        /// Optional : Add culture parameter to login, logout and access denied paths.
         /// <para>default value = true</para>
         /// <para>set to false if you need to configure the application cookie options manually</para>
         /// </summary>
-        public bool ConfigureRedirectToLoginPath { get; set; } = true;
+        public bool ConfigureRedirectPaths { get; set; } = true;
 
         /// <summary>
         /// The default culture to set during redirection to login event if no culture was set.
@@ -44,5 +37,17 @@ namespace LazZiya.ExpressLocalization
         /// <para>default value = "/Identity/Account/Login/"</para>
         /// </summary>
         public string LoginPath { get; set; } = "/Identity/Account/Login/";
+        
+        /// <summary>
+        /// The default logout path
+        /// <para>default value = "/Identity/Account/Logout/"</para>
+        /// </summary>
+        public string LogoutPath { get; set; } = "/Identity/Account/Logout/";
+        
+        /// <summary>
+        /// The default access denied path
+        /// <para>default value = "/Identity/Account/AccessDenied/"</para>
+        /// </summary>
+        public string AccessDeniedPath { get; set; } = "/Identity/Account/AccessDenied/";
     }
 }

--- a/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.csproj
+++ b/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.csproj
@@ -14,13 +14,11 @@ Localize (Views, DataAnnotations, ModelBinding, IdentityErrors, Client side vali
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>asp.net, core, razor, mvc, localization, globalization, client side, validation,scripts</PackageTags>
     <PackageReleaseNotes>
-      - Added support for DotNetCore 3.0
-      - New localizing method 'GetLocalizedString' added for backend text localization
-      - Obsolete method: 'Text' to be removed in feature release, use GetLocalizedString instead.
+      - Auto configure identity redirect paths (LoginPath, LogoutPath, AccessDeniedPath) to add culture name to the route.
     </PackageReleaseNotes>
-    <Version>3.0.0</Version>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.0.0</FileVersion>
+    <Version>3.1.0</Version>
+    <AssemblyVersion>3.1.0.0</AssemblyVersion>
+    <FileVersion>3.1.0.0</FileVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/LazZiya/ExpressLocalization/master/LazZiya.ExpressLocalization/files/icon.png</PackageIconUrl>

--- a/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.csproj
+++ b/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.csproj
@@ -14,7 +14,7 @@ Localize (Views, DataAnnotations, ModelBinding, IdentityErrors, Client side vali
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>asp.net, core, razor, mvc, localization, globalization, client side, validation,scripts</PackageTags>
     <PackageReleaseNotes>
-      - Auto configure identity redirect paths (LoginPath, LogoutPath, AccessDeniedPath) to add culture name to the route.
+      - Auto configure identity redirect paths (LoginPath, LogoutPath, AccessDeniedPath) to add culture route value to the url.
     </PackageReleaseNotes>
     <Version>3.1.0</Version>
     <AssemblyVersion>3.1.0.0</AssemblyVersion>
@@ -32,8 +32,7 @@ Localize (Views, DataAnnotations, ModelBinding, IdentityErrors, Client side vali
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.RazorPages" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.0.0" />
     <PackageReference Include="LazZiya.TagHelpers" Version="2.2.1" />
   </ItemGroup>
 

--- a/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.csproj
+++ b/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.csproj
@@ -35,6 +35,7 @@ Localize (Views, DataAnnotations, ModelBinding, IdentityErrors, Client side vali
     <PackageReference Include="Microsoft.AspNetCore.Mvc.RazorPages" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.0.0" />
     <PackageReference Include="LazZiya.TagHelpers" Version="2.2.1" />
   </ItemGroup>
 

--- a/LazZiya.ExpressLocalization/files/LazZiya.ExpressLocalization.xml
+++ b/LazZiya.ExpressLocalization/files/LazZiya.ExpressLocalization.xml
@@ -117,6 +117,18 @@
             <param name="defaultCulture">default culture name</param>
             <returns></returns>
         </member>
+        <member name="M:LazZiya.ExpressLocalization.ExpressLocalizationExtensions.ExConfigureApplicationCookie(Microsoft.Extensions.DependencyInjection.IMvcBuilder,System.String,System.String,System.String,System.String)">
+            <summary>
+            Configure application cookie and add culture value to redirect path
+            so unauthorized users will be redirected to login page and the culture will not be lost
+            </summary>
+            <param name="builder"></param>
+            <param name="loginPath">Login path</param>
+            <param name="logoutPath">Logout path</param>
+            <param name="accessDeniedPath">Access denied path</param>
+            <param name="defCulture">default culture name to add to the path when redirect to login </param>
+            <returns></returns>
+        </member>
         <member name="T:LazZiya.ExpressLocalization.ExpressLocalizationOptions">
             <summary>
             Express localization options
@@ -130,6 +142,36 @@
         <member name="P:LazZiya.ExpressLocalization.ExpressLocalizationOptions.ResourcesPath">
             <summary>
             The path to the resources folder e.g. "LocalizationResources"
+            </summary>
+        </member>
+        <member name="P:LazZiya.ExpressLocalization.ExpressLocalizationOptions.ConfigureRedirectPaths">
+            <summary>
+            Optional : Add culture parameter to login, logout and access denied paths.
+            <para>default value = true</para>
+            <para>set to false if you need to configure the application cookie options manually</para>
+            </summary>
+        </member>
+        <member name="P:LazZiya.ExpressLocalization.ExpressLocalizationOptions.DefaultCultureName">
+            <summary>
+            The default culture to set during redirection to login event if no culture was set.
+            </summary>
+        </member>
+        <member name="P:LazZiya.ExpressLocalization.ExpressLocalizationOptions.LoginPath">
+            <summary>
+            The default login path
+            <para>default value = "/Identity/Account/Login/"</para>
+            </summary>
+        </member>
+        <member name="P:LazZiya.ExpressLocalization.ExpressLocalizationOptions.LogoutPath">
+            <summary>
+            The default logout path
+            <para>default value = "/Identity/Account/Logout/"</para>
+            </summary>
+        </member>
+        <member name="P:LazZiya.ExpressLocalization.ExpressLocalizationOptions.AccessDeniedPath">
+            <summary>
+            The default access denied path
+            <para>default value = "/Identity/Account/AccessDenied/"</para>
             </summary>
         </member>
         <member name="T:LazZiya.ExpressLocalization.GenericResourceReader">


### PR DESCRIPTION
New release 3.1.0:
- Automatically configure identity redirect to paths for LoginPath, LogoutPath and AccessDeniedPath, so the culture route value will be kept while auto redirect event is fired. see issue #6 