### PR TITLE
Route segment culture provider

### DIFF
--- a/LazZiya.ExpressLocalization/ExpressLocalizationExtensions.cs
+++ b/LazZiya.ExpressLocalization/ExpressLocalizationExtensions.cs
@@ -300,7 +300,7 @@ namespace LazZiya.ExpressLocalization
 
                         if (culture == null)
                         {
-                            culture = detectedCulture.ToString() ?? defCulture;
+                            culture = detectedCulture.ToString();
                             requestPath = $"/{culture}{requestPath}";
                         }
 
@@ -314,6 +314,14 @@ namespace LazZiya.ExpressLocalization
 #else
                         var culture = ctx.HttpContext.GetRouteValue("culture") ?? defCulture;
 #endif
+                        var detectedCulture = ProviderCultureDetector.DetectCurrentCulture(_providers, ctx.HttpContext, _cultures, defCulture).Result;
+
+                        if (culture == null)
+                        {
+                            culture = detectedCulture.ToString();
+                            logoutPath = $"/{culture}{logoutPath}";
+                        }
+
                         ctx.Response.Redirect($"/{culture}{logoutPath}");
                         return Task.CompletedTask;
                     },
@@ -324,6 +332,14 @@ namespace LazZiya.ExpressLocalization
 #else
                         var culture = ctx.HttpContext.GetRouteValue("culture") ?? defCulture;
 #endif
+                        var detectedCulture = ProviderCultureDetector.DetectCurrentCulture(_providers, ctx.HttpContext, _cultures, defCulture).Result;
+
+                        if (culture == null)
+                        {
+                            culture = detectedCulture.ToString();
+                            accessDeniedPath = $"/{culture}{accessDeniedPath}";
+                        }
+
                         ctx.Response.Redirect($"/{culture}{accessDeniedPath}");
                         return Task.CompletedTask;
                     }

--- a/LazZiya.ExpressLocalization/ExpressLocalizationExtensions.cs
+++ b/LazZiya.ExpressLocalization/ExpressLocalizationExtensions.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using LazZiya.TagHelpers;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Localization;
 
 #if NETCOREAPP3_0
 #else
@@ -25,6 +26,9 @@ namespace LazZiya.ExpressLocalization
     /// </summary>
     public static class ExpressLocalizationExtensions
     {
+        private static IList<IRequestCultureProvider> _providers;
+        private static IList<CultureInfo> _cultures;
+
         /// <summary>
         /// Add all below localization settings with one step;
         /// <para>define supported cultures adn default culture</para>
@@ -252,6 +256,9 @@ namespace LazZiya.ExpressLocalization
                     ops.RequestCultureProviders.Clear();
                     ops.RequestCultureProviders.Add(new RouteSegmentCultureProvider(cultures, defaultCulture));
                 }
+
+                _providers = ops.RequestCultureProviders;
+                _cultures = cultures;
             });
 
             builder.AddRazorPagesOptions(x =>
@@ -289,9 +296,11 @@ namespace LazZiya.ExpressLocalization
 #endif
                         var requestPath = ctx.Request.Path;
 
+                        var detectedCulture = ProviderCultureDetector.DetectCurrentCulture(_providers, ctx.HttpContext, _cultures, defCulture).Result;
+
                         if (culture == null)
                         {
-                            culture = defCulture;
+                            culture = detectedCulture.ToString() ?? defCulture;
                             requestPath = $"/{culture}{requestPath}";
                         }
 

--- a/LazZiya.ExpressLocalization/ExpressLocalizationExtensions.cs
+++ b/LazZiya.ExpressLocalization/ExpressLocalizationExtensions.cs
@@ -52,7 +52,7 @@ namespace LazZiya.ExpressLocalization
             builder.Services.Configure<RequestLocalizationOptions>(_options.RequestLocalizationOptions);
 
             if (_options.ConfigureRedirectPaths)
-                builder.ExConfigureApplicationCookie(_options.LoginPath, _options.LogoutPath, _options.AccessDeniedPath, _options.DefaultCultureName);
+                builder.ExConfigureApplicationCookie(_options.LoginPath, _options.LogoutPath, _options.AccessDeniedPath, _ops.DefaultRequestCulture.Culture.Name);
 
             return builder
                 .AddViewLocalization(ops => { ops.ResourcesPath = _options.ResourcesPath; })
@@ -60,7 +60,7 @@ namespace LazZiya.ExpressLocalization
                 .ExAddDataAnnotationsLocalization<TLocalizationResource>()
                 .ExAddModelBindingLocalization<TLocalizationResource>()
                 .ExAddIdentityErrorMessagesLocalization<TLocalizationResource>()
-                .ExAddRouteValueRequestCultureProvider(_ops.SupportedCultures, _ops.DefaultRequestCulture.Culture.Name)
+                .ExAddRouteValueRequestCultureProvider(_ops.SupportedCultures, _ops.DefaultRequestCulture.Culture.Name, _options.UseAllCultureProviders)
                 .ExAddClientSideLocalizationValidationScripts();
         }
 
@@ -81,7 +81,7 @@ namespace LazZiya.ExpressLocalization
         /// <param name="options">ExpressLocalizationOptions such as supported cultures and default culture</param>
         /// <returns></returns>
         public static IMvcBuilder AddExpressLocalization<TExpressLocalizationResource, TViewLocalizationResource>(this IMvcBuilder builder, Action<ExpressLocalizationOptions> options)
-            where TExpressLocalizationResource : class 
+            where TExpressLocalizationResource : class
             where TViewLocalizationResource : class
         {
             var _options = new ExpressLocalizationOptions();
@@ -93,18 +93,18 @@ namespace LazZiya.ExpressLocalization
             builder.Services.Configure<RequestLocalizationOptions>(_options.RequestLocalizationOptions);
 
             if (_options.ConfigureRedirectPaths)
-                builder.ExConfigureApplicationCookie(_options.LoginPath, _options.LogoutPath, _options.AccessDeniedPath, _options.DefaultCultureName);
+                builder.ExConfigureApplicationCookie(_options.LoginPath, _options.LogoutPath, _options.AccessDeniedPath, _ops.DefaultRequestCulture.Culture.Name);
 
             if (_options.ConfigureRedirectPaths)
-                builder.ExConfigureApplicationCookie(_options.LoginPath, _options.LogoutPath, _options.AccessDeniedPath, _options.DefaultCultureName);
+                builder.ExConfigureApplicationCookie(_options.LoginPath, _options.LogoutPath, _options.AccessDeniedPath, _ops.DefaultRequestCulture.Culture.Name);
 
             return builder
-                .AddViewLocalization(ops=> { ops.ResourcesPath = _options.ResourcesPath; })
+                .AddViewLocalization(ops => { ops.ResourcesPath = _options.ResourcesPath; })
                 .ExAddSharedCultureLocalizer<TViewLocalizationResource>()
                 .ExAddDataAnnotationsLocalization<TExpressLocalizationResource>()
                 .ExAddModelBindingLocalization<TExpressLocalizationResource>()
                 .ExAddIdentityErrorMessagesLocalization<TExpressLocalizationResource>()
-                .ExAddRouteValueRequestCultureProvider(_ops.SupportedCultures, _ops.DefaultRequestCulture.Culture.Name)
+                .ExAddRouteValueRequestCultureProvider(_ops.SupportedCultures, _ops.DefaultRequestCulture.Culture.Name, _options.UseAllCultureProviders)
                 .ExAddClientSideLocalizationValidationScripts();
         }
 
@@ -141,7 +141,7 @@ namespace LazZiya.ExpressLocalization
             builder.Services.Configure<RequestLocalizationOptions>(_options.RequestLocalizationOptions);
 
             if (_options.ConfigureRedirectPaths)
-                builder.ExConfigureApplicationCookie(_options.LoginPath, _options.LogoutPath, _options.AccessDeniedPath, _options.DefaultCultureName);
+                builder.ExConfigureApplicationCookie(_options.LoginPath, _options.LogoutPath, _options.AccessDeniedPath, _ops.DefaultRequestCulture.Culture.Name);
 
             return builder
                 .AddViewLocalization(ops => { ops.ResourcesPath = _options.ResourcesPath; })
@@ -149,7 +149,7 @@ namespace LazZiya.ExpressLocalization
                 .ExAddDataAnnotationsLocalization<TDataAnnotationsLocalizationResource>()
                 .ExAddModelBindingLocalization<TModelBindingLocalizationResource>()
                 .ExAddIdentityErrorMessagesLocalization<TIdentityErrorsLocalizationResource>()
-                .ExAddRouteValueRequestCultureProvider(_ops.SupportedCultures, _ops.DefaultRequestCulture.Culture.Name)
+                .ExAddRouteValueRequestCultureProvider(_ops.SupportedCultures, _ops.DefaultRequestCulture.Culture.Name, _options.UseAllCultureProviders)
                 .ExAddClientSideLocalizationValidationScripts();
         }
 
@@ -239,11 +239,19 @@ namespace LazZiya.ExpressLocalization
         /// <param name="builder"></param>
         /// <param name="cultures">List of supported cultures</param>
         /// <param name="defaultCulture">default culture name</param>
+        /// <param name="useAllProviders">true to register all culture providers (Route, QueryString, Cookie, AcceptedLanguageHeader), false to use only Route culture provider.</param>
         /// <returns></returns>
-        public static IMvcBuilder ExAddRouteValueRequestCultureProvider(this IMvcBuilder builder, IList<CultureInfo> cultures, string defaultCulture)
+        public static IMvcBuilder ExAddRouteValueRequestCultureProvider(this IMvcBuilder builder, IList<CultureInfo> cultures, string defaultCulture, bool useAllProviders)
         {
-            builder.Services.Configure<RequestLocalizationOptions>(ops=> {
-                ops.RequestCultureProviders.Insert(0, new RouteValueRequestCultureProvider(cultures, defaultCulture));
+            builder.Services.Configure<RequestLocalizationOptions>(ops =>
+            {
+                if (useAllProviders)
+                    ops.RequestCultureProviders.Insert(0, new RouteSegmentCultureProvider(cultures, defaultCulture));
+                else
+                {
+                    ops.RequestCultureProviders.Clear();
+                    ops.RequestCultureProviders.Add(new RouteSegmentCultureProvider(cultures, defaultCulture));
+                }
             });
 
             builder.AddRazorPagesOptions(x =>

--- a/LazZiya.ExpressLocalization/ExpressLocalizationOptions.cs
+++ b/LazZiya.ExpressLocalization/ExpressLocalizationOptions.cs
@@ -16,6 +16,13 @@ namespace LazZiya.ExpressLocalization
         public Action<RequestLocalizationOptions> RequestLocalizationOptions { get; set; }
 
         /// <summary>
+        /// Optional, default value true.
+        ///<para>true to register all culture providers (Route, QueryString, Cookie, AcceptLanguageHeader) </para>
+        ///<para>false to use only Route culture provider.</para>
+        /// </summary>
+        public bool UseAllCultureProviders { get; set; } = true;
+
+        /// <summary>
         /// The path to the resources folder e.g. "LocalizationResources"
         /// </summary>
         public string ResourcesPath { get; set; } = "";
@@ -30,6 +37,7 @@ namespace LazZiya.ExpressLocalization
         /// <summary>
         /// The default culture to set during redirection to login event if no culture was set.
         /// </summary>
+        [Obsolete("DefaultCultureName will be removed in a future version. It is not necessary since we already providing default culture in localization options setup.")]
         public string DefaultCultureName { get; set; } = "en";
 
         /// <summary>

--- a/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.csproj
+++ b/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.csproj
@@ -14,11 +14,13 @@ Localize (Views, DataAnnotations, ModelBinding, IdentityErrors, Client side vali
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>asp.net, core, razor, mvc, localization, globalization, client side, validation,scripts</PackageTags>
     <PackageReleaseNotes>
-      - update dependency Microsoft.AspNetCore.Identity min. supported version to v2.0.4
+      - New optional boolean property - UseAllCultureProviders.
+      - Route culture provider is not blocking other providres any more; if route culture is not found, next provider will be checked, if no culture is found default culture will be used.
+      - fix dependency Microsoft.AspNetCore.Identity min. supported version to v2.0.4
     </PackageReleaseNotes>
-    <Version>3.2.0</Version>
-    <AssemblyVersion>3.2.0.0</AssemblyVersion>
-    <FileVersion>3.2.0.0</FileVersion>
+    <Version>3.1.2</Version>
+    <AssemblyVersion>3.1.2.0</AssemblyVersion>
+    <FileVersion>3.1.2.0</FileVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/LazZiya/ExpressLocalization/master/LazZiya.ExpressLocalization/files/icon.png</PackageIconUrl>

--- a/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.csproj
+++ b/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.csproj
@@ -14,8 +14,8 @@ Localize (Views, DataAnnotations, ModelBinding, IdentityErrors, Client side vali
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>asp.net, core, razor, mvc, localization, globalization, client side, validation,scripts</PackageTags>
     <PackageReleaseNotes>
-      - New optional boolean property - UseAllCultureProviders.
-      - Route culture provider is not blocking other providres any more; if route culture is not found, next provider will be checked, if no culture is found default culture will be used.
+      - New optional boolean property : UseAllCultureProviders.
+      - Route culture provider is not blocking other providres any more; if culture value is not found in route, next provider will be checked (cookie, accepted language header, etc.), if no culture is found default culture will be used.
       - fix dependency Microsoft.AspNetCore.Identity min. supported version to v2.0.4
     </PackageReleaseNotes>
     <Version>3.1.2</Version>

--- a/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.csproj
+++ b/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.csproj
@@ -16,9 +16,9 @@ Localize (Views, DataAnnotations, ModelBinding, IdentityErrors, Client side vali
     <PackageReleaseNotes>
       - update dependency Microsoft.AspNetCore.Identity min. supported version to v2.0.4
     </PackageReleaseNotes>
-    <Version>3.1.1</Version>
-    <AssemblyVersion>3.1.1.0</AssemblyVersion>
-    <FileVersion>3.1.1.0</FileVersion>
+    <Version>3.2.0</Version>
+    <AssemblyVersion>3.2.0.0</AssemblyVersion>
+    <FileVersion>3.2.0.0</FileVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/LazZiya/ExpressLocalization/master/LazZiya.ExpressLocalization/files/icon.png</PackageIconUrl>
@@ -32,7 +32,7 @@ Localize (Views, DataAnnotations, ModelBinding, IdentityErrors, Client side vali
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.RazorPages" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.0.4" />
     <PackageReference Include="LazZiya.TagHelpers" Version="2.2.1" />
   </ItemGroup>
 

--- a/LazZiya.ExpressLocalization/ProviderCultureDetector.cs
+++ b/LazZiya.ExpressLocalization/ProviderCultureDetector.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LazZiya.ExpressLocalization
+{
+    /// <summary>
+    /// Detects the current culture result depending on currently registered culture providers
+    /// </summary>
+    public class ProviderCultureDetector
+    {
+        private readonly RequestLocalizationOptions _ops;
+
+        /// <summary>
+        /// Detects the current culture result depending on currently registered culture providers
+        /// </summary>
+        public ProviderCultureDetector(RequestLocalizationOptions ops)
+        {
+            _ops = ops;
+        }
+
+        /// <summary>
+        /// Detect current culture according to the registered culture providers, if no culture is detected it will return default culture.
+        /// </summary>
+        /// <param name="httpContext">requests HttpContext</param>
+        /// <returns>ProviderCultureResult</returns>
+        public async Task<ProviderCultureResult> DetectCurrentCulture(HttpContext httpContext)
+        {
+            foreach(var p in _ops.RequestCultureProviders)
+            {
+                var culture = await p.DetermineProviderCultureResult(httpContext);
+
+                if (culture != null)
+                    return culture;
+            }
+
+            return new ProviderCultureResult(_ops.DefaultRequestCulture.Culture.Name);
+        }
+    }
+}

--- a/LazZiya.ExpressLocalization/RouteSegmentCultureProvider.cs
+++ b/LazZiya.ExpressLocalization/RouteSegmentCultureProvider.cs
@@ -8,9 +8,9 @@ using System.Threading.Tasks;
 namespace LazZiya.ExpressLocalization
 {
     /// <summary>
-    /// Register Route value based request localization culture provider
+    /// Register Route segment based request localization culture provider
     /// </summary>
-    public class RouteValueRequestCultureProvider : IRequestCultureProvider
+    public class RouteSegmentCultureProvider : IRequestCultureProvider
     {
         private readonly string DefaultCulture;
         private readonly IList<CultureInfo> SupportedCultures;
@@ -20,7 +20,7 @@ namespace LazZiya.ExpressLocalization
         /// </summary>
         /// <param name="supportedCultures">list of supported cultures</param>
         /// <param name="defaultCulture">default culture name e.g. en-US</param>
-        public RouteValueRequestCultureProvider(IList<CultureInfo> supportedCultures, string defaultCulture)
+        public RouteSegmentCultureProvider(IList<CultureInfo> supportedCultures, string defaultCulture)
         {
             DefaultCulture = defaultCulture;
             SupportedCultures = supportedCultures;
@@ -38,14 +38,16 @@ namespace LazZiya.ExpressLocalization
             if (string.IsNullOrWhiteSpace(path))
             {
                 // Path is empty! returning default culture
-                return Task.FromResult(new ProviderCultureResult(DefaultCulture));
+                //return Task.FromResult(new ProviderCultureResult(DefaultCulture));
+                return Task.FromResult<ProviderCultureResult>(null);
             }
 
             var routeValues = httpContext.Request.Path.Value.Split('/');
             if (routeValues.Count() <= 1)
             {
                 // No path parameter detected! returning default culture
-                return Task.FromResult(new ProviderCultureResult(DefaultCulture));
+                //return Task.FromResult(new ProviderCultureResult(DefaultCulture));
+                return Task.FromResult<ProviderCultureResult>(null);
             }
 
             if (!SupportedCultures.Any(x =>
@@ -53,7 +55,8 @@ namespace LazZiya.ExpressLocalization
                  x.Name.ToLower() == routeValues[1].ToLower()))
             {
                 // Path culture not ercognized! returning default culture
-                return Task.FromResult(new ProviderCultureResult(DefaultCulture));
+                //return Task.FromResult(new ProviderCultureResult(DefaultCulture));
+                return Task.FromResult<ProviderCultureResult>(null);
             }
 
             // culture selected successfuly

--- a/LazZiya.ExpressLocalization/files/LazZiya.ExpressLocalization.xml
+++ b/LazZiya.ExpressLocalization/files/LazZiya.ExpressLocalization.xml
@@ -108,13 +108,14 @@
             <param name="builder"></param>
             <returns></returns>
         </member>
-        <member name="M:LazZiya.ExpressLocalization.ExpressLocalizationExtensions.ExAddRouteValueRequestCultureProvider(Microsoft.Extensions.DependencyInjection.IMvcBuilder,System.Collections.Generic.IList{System.Globalization.CultureInfo},System.String)">
+        <member name="M:LazZiya.ExpressLocalization.ExpressLocalizationExtensions.ExAddRouteValueRequestCultureProvider(Microsoft.Extensions.DependencyInjection.IMvcBuilder,System.Collections.Generic.IList{System.Globalization.CultureInfo},System.String,System.Boolean)">
             <summary>
             Add RouteValueRequestCultureProvider, so localization will be based on route value {culture}
             </summary>
             <param name="builder"></param>
             <param name="cultures">List of supported cultures</param>
             <param name="defaultCulture">default culture name</param>
+            <param name="useAllProviders">true to register all culture providers (Route, QueryString, Cookie, AcceptedLanguageHeader), false to use only Route culture provider.</param>
             <returns></returns>
         </member>
         <member name="M:LazZiya.ExpressLocalization.ExpressLocalizationExtensions.ExConfigureApplicationCookie(Microsoft.Extensions.DependencyInjection.IMvcBuilder,System.String,System.String,System.String,System.String)">
@@ -138,6 +139,13 @@
             <summary>
             Specific options for the Mİcrosoft.AspNetCore.Localizarion.RequestLocalizatonMiddleware
             </summary>
+        </member>
+        <member name="P:LazZiya.ExpressLocalization.ExpressLocalizationOptions.UseAllCultureProviders">
+             <summary>
+             Optional, default value true.
+            <para>true to register all culture providers (Route, QueryString, Cookie, AcceptLanguageHeader) </para>
+            <para>false to use only Route culture provider.</para>
+             </summary>
         </member>
         <member name="P:LazZiya.ExpressLocalization.ExpressLocalizationOptions.ResourcesPath">
             <summary>
@@ -489,6 +497,42 @@
             </para>
             </summary>
         </member>
+        <member name="T:LazZiya.ExpressLocalization.ProviderCultureDetector">
+            <summary>
+            Detects the current culture result depending on currently registered culture providers
+            </summary>
+        </member>
+        <member name="M:LazZiya.ExpressLocalization.ProviderCultureDetector.#ctor(Microsoft.AspNetCore.Builder.RequestLocalizationOptions)">
+            <summary>
+            Detects the current culture result depending on currently registered culture providers
+            </summary>
+        </member>
+        <member name="M:LazZiya.ExpressLocalization.ProviderCultureDetector.DetectCurrentCulture(Microsoft.AspNetCore.Http.HttpContext)">
+            <summary>
+            Detect current culture according to the registered culture providers, if no culture is detected it will return default culture.
+            </summary>
+            <param name="httpContext">requests HttpContext</param>
+            <returns>ProviderCultureResult</returns>
+        </member>
+        <member name="T:LazZiya.ExpressLocalization.RouteSegmentCultureProvider">
+            <summary>
+            Register Route segment based request localization culture provider
+            </summary>
+        </member>
+        <member name="M:LazZiya.ExpressLocalization.RouteSegmentCultureProvider.#ctor(System.Collections.Generic.IList{System.Globalization.CultureInfo},System.String)">
+            <summary>
+            Register Route value based request localization culture provider
+            </summary>
+            <param name="supportedCultures">list of supported cultures</param>
+            <param name="defaultCulture">default culture name e.g. en-US</param>
+        </member>
+        <member name="M:LazZiya.ExpressLocalization.RouteSegmentCultureProvider.DetermineProviderCultureResult(Microsoft.AspNetCore.Http.HttpContext)">
+            <summary>
+            Determine the culture resut according to the {culture} route paramter value
+            </summary>
+            <param name="httpContext"></param>
+            <returns></returns>
+        </member>
         <member name="T:LazZiya.ExpressLocalization.RouteTemplateModelConvention">
             <summary>
             Configure global template for page route, so culture parameter will be placed at the beginning of the URL
@@ -499,25 +543,6 @@
             automatically invoked
             </summary>
             <param name="model"></param>
-        </member>
-        <member name="T:LazZiya.ExpressLocalization.RouteValueRequestCultureProvider">
-            <summary>
-            Register Route value based request localization culture provider
-            </summary>
-        </member>
-        <member name="M:LazZiya.ExpressLocalization.RouteValueRequestCultureProvider.#ctor(System.Collections.Generic.IList{System.Globalization.CultureInfo},System.String)">
-            <summary>
-            Register Route value based request localization culture provider
-            </summary>
-            <param name="supportedCultures">list of supported cultures</param>
-            <param name="defaultCulture">default culture name e.g. en-US</param>
-        </member>
-        <member name="M:LazZiya.ExpressLocalization.RouteValueRequestCultureProvider.DetermineProviderCultureResult(Microsoft.AspNetCore.Http.HttpContext)">
-            <summary>
-            Determine the culture resut according to the {culture} route paramter value
-            </summary>
-            <param name="httpContext"></param>
-            <returns></returns>
         </member>
         <member name="T:LazZiya.ExpressLocalization.SharedCultureLocalizer">
             <summary>

--- a/LazZiya.ExpressLocalization/files/LazZiya.ExpressLocalization.xml
+++ b/LazZiya.ExpressLocalization/files/LazZiya.ExpressLocalization.xml
@@ -502,16 +502,14 @@
             Detects the current culture result depending on currently registered culture providers
             </summary>
         </member>
-        <member name="M:LazZiya.ExpressLocalization.ProviderCultureDetector.#ctor(Microsoft.AspNetCore.Builder.RequestLocalizationOptions)">
+        <member name="M:LazZiya.ExpressLocalization.ProviderCultureDetector.DetectCurrentCulture(System.Collections.Generic.IList{Microsoft.AspNetCore.Localization.IRequestCultureProvider},Microsoft.AspNetCore.Http.HttpContext,System.Collections.Generic.IList{System.Globalization.CultureInfo},System.String)">
             <summary>
-            Detects the current culture result depending on currently registered culture providers
+            Detect the culture for the current request according to the available cultures and their availability in the registered culture providers, if no culture is detected it will return default culture.
             </summary>
-        </member>
-        <member name="M:LazZiya.ExpressLocalization.ProviderCultureDetector.DetectCurrentCulture(Microsoft.AspNetCore.Http.HttpContext)">
-            <summary>
-            Detect current culture according to the registered culture providers, if no culture is detected it will return default culture.
-            </summary>
+            <param name="providers">List of currently registered culture providers</param>
             <param name="httpContext">requests HttpContext</param>
+            <param name="cultures">List of supported cultures</param>
+            <param name="defCulture">default culture name</param>
             <returns>ProviderCultureResult</returns>
         </member>
         <member name="T:LazZiya.ExpressLocalization.RouteSegmentCultureProvider">


### PR DESCRIPTION
## Release v3.1.2
### New optional Boolean parameter: UseAllCultureProviders
true to use all culture providers in order, set to false to use only RouteSegmentCultureProvider.

### RouteSegmentCultureProvider 
Built in route culture provider is not blocking other culture providers any more, if culture value is not found in the route culture provider, it will be checked in other providers by their order, if not culture value is  detected the default culture will be used. This improvement is done according to enhancement request https://github.com/LazZiya/ExpressLocalization/issues/4

### Culture providers by order:
  - RouteSegmentCultureProvider
  - QueryStringRequestCultureProvider
  - CookieRequestCultureProvider
  - AcceptedLanguageHeaderCultureProvider
