### PR TITLE
Fix for ExStringLenght

### DIFF
--- a/LazZiya.ExpressLocalization/DataAnnotations/Adapters/ExStringLengthAttributeAdapter.cs
+++ b/LazZiya.ExpressLocalization/DataAnnotations/Adapters/ExStringLengthAttributeAdapter.cs
@@ -9,8 +9,9 @@ namespace LazZiya.ExpressLocalization.DataAnnotations.Adapters
     /// Adapter to provide localized error message for <see cref="ExStringLengthAttribute"/>
     /// </summary>
     public class ExStringLengthAttributeAdapter : AttributeAdapterBase<ExStringLengthAttribute>
-    {
+  {
         private readonly int MaxLenght;
+        private readonly int MinLenght;
 
         /// <summary>
         /// Initialize a new instance of <see cref="ExStringLengthAttributeAdapter"/>
@@ -20,6 +21,7 @@ namespace LazZiya.ExpressLocalization.DataAnnotations.Adapters
         public ExStringLengthAttributeAdapter(ExStringLengthAttribute attribute, IStringLocalizer stringLocalizer) : base(attribute, stringLocalizer)
         {
             MaxLenght = attribute.MaximumLength;
+            MinLenght = attribute.MinimumLength;
         }
 
         /// <summary>
@@ -33,7 +35,14 @@ namespace LazZiya.ExpressLocalization.DataAnnotations.Adapters
 
             MergeAttribute(context.Attributes, "data-val", "true");
             MergeAttribute(context.Attributes, "data-val-length", GetErrorMessage(context));
-            MergeAttribute(context.Attributes, "data-val-length-max", $"{MaxLenght}");
+            if (MaxLenght != int.MaxValue)
+            {
+              MergeAttribute(context.Attributes, "data-val-length-max", $"{MaxLenght}");
+            }
+            if (MinLenght > 0)
+            {
+              MergeAttribute(context.Attributes, "data-val-length-min", $"{MinLenght}");
+            }
         }
 
         /// <summary>
@@ -46,7 +55,7 @@ namespace LazZiya.ExpressLocalization.DataAnnotations.Adapters
             if (validationContext == null)
                 throw new NullReferenceException(nameof(validationContext));
 
-            return GetErrorMessage(validationContext.ModelMetadata, validationContext.ModelMetadata.GetDisplayName(), MaxLenght);
+            return GetErrorMessage(validationContext.ModelMetadata, validationContext.ModelMetadata.GetDisplayName(), MaxLenght, MinLenght);
         }
     }
 }

--- a/LazZiya.ExpressLocalization/DataAnnotations/ExStringLengthAttribute.cs
+++ b/LazZiya.ExpressLocalization/DataAnnotations/ExStringLengthAttribute.cs
@@ -9,6 +9,23 @@ namespace LazZiya.ExpressLocalization.DataAnnotations
     /// </summary>
     public sealed class ExStringLengthAttribute : StringLengthAttribute
     {
+        private bool IsCustomError;
+
+        /// <summary>
+        /// Gets or sets the minimum length of a string.
+        /// </summary>
+        /// <returns>The minimum length of a string.</returns>
+        public new int MinimumLength
+        {
+            get => base.MinimumLength; 
+            set
+            {
+                base.MinimumLength = value;
+                if (!IsCustomError)
+                    this.ErrorMessage = DataAnnotationsErrorMessages.StringLengthAttribute_ValidationErrorIncludingMinimum;
+            }
+         }
+
         /// <summary>
         /// Initializes a new instance of the LazZiya.ExpressLocalization.DataAnnotations.ExStringLengthAttribute 
         /// class by using a specified maximum length.
@@ -16,6 +33,7 @@ namespace LazZiya.ExpressLocalization.DataAnnotations
         /// <param name="maximumLength">The maximum length of a string.</param>
         public ExStringLengthAttribute(int maximumLength) : base(maximumLength)
         {
+            this.IsCustomError = !(ErrorMessage is null);
             this.ErrorMessage = ErrorMessage ?? DataAnnotationsErrorMessages.StringLengthAttribute_ValidationError;
         }
     }

--- a/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.xml
+++ b/LazZiya.ExpressLocalization/LazZiya.ExpressLocalization.xml
@@ -297,6 +297,12 @@
             And provides a localized error message
             </summary>
         </member>
+        <member name="P:LazZiya.ExpressLocalization.DataAnnotations.ExStringLengthAttribute.MinimumLength">
+            <summary>
+            Gets or sets the minimum length of a string.
+            </summary>
+            <returns>The minimum length of a string.</returns>
+        </member>
         <member name="M:LazZiya.ExpressLocalization.DataAnnotations.ExStringLengthAttribute.#ctor(System.Int32)">
             <summary>
             Initializes a new instance of the LazZiya.ExpressLocalization.DataAnnotations.ExStringLengthAttribute 


### PR DESCRIPTION
Added MinimumLenght validation on the Adapter.
And setting the appropriated ErrorMessage when it's setted the MinimumLength property.